### PR TITLE
fix: Todo完了ボタンのCSRF 403エラーを修正

### DIFF
--- a/templates/todo/todo_list.html
+++ b/templates/todo/todo_list.html
@@ -3,6 +3,7 @@
 {% block title %}Todo一覧 - Todo App{% endblock %}
 
 {% block content %}
+{% csrf_token %}
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h2>Todo一覧</h2>
     <a href="{% url 'todo_create' %}" class="btn btn-primary">新しいTodoを作成</a>


### PR DESCRIPTION
## 概要
Issue で報告されたTodo完了ボタンクリック時のCSRF 403エラーを修正しました。

## 問題
- `todo_list.html`のJavaScriptでCSRFトークンを取得しようとしているが、テンプレートに`{% csrf_token %}`タグが存在しない
- そのため、AJAX POSTリクエスト時にCSRFトークンが`undefined`となり403エラーが発生

## 解決方法
- `templates/todo/todo_list.html`に`{% csrf_token %}`タグを追加
- 既存のJavaScriptコードがCSRFトークンを正常に取得できるようになる

## 変更内容
- `templates/todo/todo_list.html`の`{% block content %}`直下に`{% csrf_token %}`を追加

## テスト結果
- ✅ 既存テスト21件すべて通過
- ✅ 回帰テストでの問題なし

## 動作確認
修正前:
```
[24/Jun/2025 21:57:19] "POST /toggle/2/ HTTP/1.1" 403 2534
```

修正後:
- Todo完了ボタンクリック時に正常に状態が切り替わる
- 403エラーが発生しない

## レビューポイント
- CSRFトークンが適切にテンプレートに埋め込まれているか
- 既存機能に影響がないか
- セキュリティ要件を満たしているか

🤖 Generated with [Claude Code](https://claude.ai/code)